### PR TITLE
GST-179 Added filter criteria for subuser role on the subusers list, …

### DIFF
--- a/modules/custom/features_export/view_kms_subuser/view_kms_subuser.views_default.inc
+++ b/modules/custom/features_export/view_kms_subuser/view_kms_subuser.views_default.inc
@@ -143,6 +143,13 @@ function view_kms_subuser_views_default_views() {
   $handler->display->display_options['arguments']['uid']['summary']['number_of_records'] = '0';
   $handler->display->display_options['arguments']['uid']['summary']['format'] = 'default_summary';
   $handler->display->display_options['arguments']['uid']['summary_options']['items_per_page'] = '25';
+  /* Filter criterion: User: Roles */
+  $handler->display->display_options['filters']['rid']['id'] = 'rid';
+  $handler->display->display_options['filters']['rid']['table'] = 'users_roles';
+  $handler->display->display_options['filters']['rid']['field'] = 'rid';
+  $handler->display->display_options['filters']['rid']['value'] = array(
+    9 => '9',
+  );
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');


### PR DESCRIPTION
…so users created normally is not shown, this is due to the relations module, that always create a relationship between user and subuser, users created as subusers will get subuser as role so this can be used as filtering.